### PR TITLE
Remove panic when si-migrator config not found

### DIFF
--- a/cmd/generate_docs/main.go
+++ b/cmd/generate_docs/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"github.com/vmware-tanzu/service-instance-migrator-for-cloud-foundry/pkg/migrate"
 	"os"
 
@@ -27,11 +26,7 @@ import (
 )
 
 func main() {
-	cfg, err := config.NewDefaultConfig()
-	if err != nil {
-		fmt.Printf("%v\n", err)
-		os.Exit(1)
-	}
+	cfg := config.NewDefaultConfig()
 
 	rootCmd := cmd.CreateRootCommand(
 		cfg,

--- a/cmd/si-migrator/main.go
+++ b/cmd/si-migrator/main.go
@@ -16,10 +16,10 @@ package main
 
 import (
 	"fmt"
-	boshcli "github.com/vmware-tanzu/service-instance-migrator-for-cloud-foundry/pkg/bosh/cli"
 	"os"
 
 	"github.com/vmware-tanzu/service-instance-migrator-for-cloud-foundry/pkg/bosh"
+	boshcli "github.com/vmware-tanzu/service-instance-migrator-for-cloud-foundry/pkg/bosh/cli"
 	"github.com/vmware-tanzu/service-instance-migrator-for-cloud-foundry/pkg/cmd"
 	"github.com/vmware-tanzu/service-instance-migrator-for-cloud-foundry/pkg/config"
 	"github.com/vmware-tanzu/service-instance-migrator-for-cloud-foundry/pkg/credhub"
@@ -33,10 +33,7 @@ import (
 
 func main() {
 	defer recoverConfigLoader()
-	cfg, err := config.NewDefaultConfig()
-	if err != nil {
-		log.Fatalln(err)
-	}
+	cfg := config.NewDefaultConfig()
 
 	commandExists := func(args []string) (*cobra.Command, bool) {
 		noopCmd := cmd.CreateRootCommand(

--- a/main_test.go
+++ b/main_test.go
@@ -82,11 +82,7 @@ func exportTestOrgSpace(t *testing.T) {
 		log.Fatalf("could not get current working dir, %s", err)
 	}
 
-	cfg, err := config.NewDefaultConfig()
-	if err != nil {
-		log.Fatalf("could not load config, %s", err)
-	}
-
+	cfg := config.NewDefaultConfig()
 	mr, err := config.NewMigrationReader(cfg)
 	if err != nil {
 		log.Fatalln(err)
@@ -119,11 +115,7 @@ func importTestOrgSpace(t *testing.T) {
 		log.Fatalf("could not get current working dir, %s", err)
 	}
 
-	cfg, err := config.NewDefaultConfig()
-	if err != nil {
-		log.Fatalf("could not load config, %s", err)
-	}
-
+	cfg := config.NewDefaultConfig()
 	mr, err := config.NewMigrationReader(cfg)
 	if err != nil {
 		log.Fatalln(err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -151,7 +151,7 @@ type CCDBProperties struct {
 	SSHHost, SSHUsername, SSHPrivateKey     string
 }
 
-func NewDefaultConfig() (*Config, error) {
+func NewDefaultConfig() *Config {
 	configDir := ""
 
 	if cfgHome, ok := os.LookupEnv("SI_MIGRATOR_CONFIG_HOME"); ok {
@@ -159,16 +159,16 @@ func NewDefaultConfig() (*Config, error) {
 	}
 
 	if configFile, ok := os.LookupEnv("SI_MIGRATOR_CONFIG_FILE"); ok {
-		return New(configDir, configFile), nil
+		return New(configDir, configFile)
 	}
 
 	if _, ok := hasSuffix(configDir); ok {
 		configFile := configDir
 		configDir, _ = filepath.Split(configFile)
-		return New(configDir, configFile), nil
+		return New(configDir, configFile)
 	}
 
-	return New(configDir, ""), nil
+	return New(configDir, "")
 }
 
 func New(configDir string, configFile string) *Config {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -304,11 +304,10 @@ func (c *Config) initViperConfig() {
 
 	// If a config file is found, read it in.
 	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-			log.Errorf("failed to load config file: %s, error: %s", v.ConfigFileUsed(), err)
-			panic(err)
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			log.Errorf("config not found, error: %s", err)
 		} else {
-			log.Errorf("failed to read config, error: %s", err)
+			log.Errorf("failed to load config file: %s, error: %s", v.ConfigFileUsed(), err)
 			panic(err)
 		}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -145,11 +145,7 @@ func TestNewDefaultConfig(t *testing.T) {
 			if tt.beforeFunc != nil {
 				tt.beforeFunc()
 			}
-			got, err := NewDefaultConfig()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewDefaultConfig() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := NewDefaultConfig()
 			if diff := cmp.Diff(tt.want, got,
 				cmpopts.IgnoreUnexported(Config{}),
 			); diff != "" {

--- a/pkg/config/yaml_reader.go
+++ b/pkg/config/yaml_reader.go
@@ -63,10 +63,7 @@ func ReadFromDir(path string) (*YAMLMigrationReader, error) {
 	var r *YAMLMigrationReader
 
 	if len(b) == 0 {
-		cfg, err := NewDefaultConfig()
-		if err != nil {
-			return nil, err
-		}
+		cfg := NewDefaultConfig()
 		r = &YAMLMigrationReader{
 			migration:      &cfg.Migration,
 			migrationBytes: b,


### PR DESCRIPTION
We only log an error message when `si-migrator.yml` is not found. If you try to run another command that requires `si-migrator.yml`, then you'll get an error: "Error validating config" and the program will exit.